### PR TITLE
Civis util uploader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM irose/citywide-civis-lab:fbb9b9646aeb
+FROM irose/citywide-civis-lab:sha-0b7061d
 
 COPY conda-requirements.txt /tmp/
 RUN conda install --yes -c conda-forge --file /tmp/conda-requirements.txt

--- a/data/upload-data.py
+++ b/data/upload-data.py
@@ -3,20 +3,42 @@ Upload the CSV to GitHub.
 We will continue to use parquets in S3.
 Let's check in CSV for others.
 """
-import base64
+#import base64
 import civis
-import fsspec
+#import fsspec
 import os
-import pandas as pd
-import requests
+#import pandas as pd
+#import requests
+
+from civis_aqueduct_utils.github import upload_file_to_github, DEFAULT_COMMITTER
 
 # Constants for loading the file to master branch
 TOKEN = os.environ["GITHUB_TOKEN_PASSWORD"]
-BASE = "https://api.github.com"
 REPO = "CityOfLosAngeles/covid19-indicators"
 BRANCH = "master"
 S3_FILE_PATH = "s3://public-health-dashboard/jhu_covid19/"
+COMMIT_MESSAGE = "Update data"
 
+datasets = [
+    "city-of-la-cases.csv", 
+    "county-city-testing.csv", 
+    "hospital-availability.csv", 
+    "la-county-neighborhood-time-series.parquet", 
+    "la-county-neighborhood-time-series.csv", 
+    "ca-hospital-and-surge-capacity.csv"
+]
+
+for file_name in datasets:
+    upload_file_to_github(
+        TOKEN,
+        REPO,
+        BRANCH,
+        f"data/{file_name}",
+        f"{S3_FILE_PATH}{file_name}",
+        f"{COMMIT_MESSAGE}",
+        DEFAULT_COMMITTER,
+    )
+"""
 def upload_file(file_name):
     PATH = f"data/{file_name}"
 
@@ -57,6 +79,6 @@ upload_file("city-of-la-cases.csv")
 upload_file("county-city-testing.csv")
 upload_file("hospital-availability.csv")
 upload_file("la-county-neighborhood-time-series.parquet")
-upload_file("la-county-neighborhood-time-series.csv")
 # CA open data portal data
 upload_file("ca-hospital-and-surge-capacity.csv")
+"""

--- a/data/upload-data.py
+++ b/data/upload-data.py
@@ -3,12 +3,8 @@ Upload the CSV to GitHub.
 We will continue to use parquets in S3.
 Let's check in CSV for others.
 """
-#import base64
 import civis
-#import fsspec
 import os
-#import pandas as pd
-#import requests
 
 from civis_aqueduct_utils.github import upload_file_to_github, DEFAULT_COMMITTER
 
@@ -38,47 +34,3 @@ for file_name in datasets:
         f"{COMMIT_MESSAGE}",
         DEFAULT_COMMITTER,
     )
-"""
-def upload_file(file_name):
-    PATH = f"data/{file_name}"
-
-    # Get the sha of the previous version
-    r = requests.get(
-        f"{BASE}/repos/{REPO}/contents/{PATH}",
-        params={"ref": BRANCH},
-        headers={"Authorization": f"token {TOKEN}"},
-    )
-    r.raise_for_status()
-    sha = r.json()["sha"]
-
-    # Upload the new version
-    MY_FILE = f"{S3_FILE_PATH}{file_name}"
-
-    with fsspec.open(MY_FILE, "rb") as f:
-        contents = f.read()
-
-    r = requests.put(
-        f"{BASE}/repos/{REPO}/contents/{PATH}",
-        headers={"Authorization": f"token {TOKEN}"},
-        json={
-            "message": "Update data",
-            "committer": {
-                "name": "Los Angeles ITA data team",
-                "email": "ITAData@lacity.org",
-            },
-            "branch": BRANCH,
-            "sha": sha,
-            "content": base64.b64encode(contents).decode("utf-8"),
-        },
-    )
-    r.raise_for_status()
-
-
-# LA county or city data
-upload_file("city-of-la-cases.csv")
-upload_file("county-city-testing.csv")
-upload_file("hospital-availability.csv")
-upload_file("la-county-neighborhood-time-series.parquet")
-# CA open data portal data
-upload_file("ca-hospital-and-surge-capacity.csv")
-"""

--- a/reopening-sources.md
+++ b/reopening-sources.md
@@ -75,7 +75,7 @@ Examples of reopening indicators used by NY and Chicago are included for LA to b
 * Germany's research on [who has antibodies, how long antibodies last after infection, and what levels of antibodies are needed to prevent re-infection](https://www.nytimes.com/2020/04/18/world/europe/with-broad-random-tests-for-antibodies-germany-seeks-path-out-of-lockdown.html)
 * [How long do antibodies last?](https://www.nytimes.com/2020/05/07/health/coronavirus-antibody-prevalence.html) Remains to be seen.
     * Spain, with one of the worst outbreaks in Europe, [only sees about 5% of its population with immunity](https://www.vox.com/2020/5/16/21259492/covid-antibodies-spain-serology-study-coronavirus-immunity) and in [NYC, with the worst US outbreak](https://www.nytimes.com/interactive/2020/05/28/upshot/coronavirus-herd-immunity.html), about 20% of its population.
-    * Antibodies don't last longer [than a couple months](https://www.nytimes.com/2020/06/18/health/coronavirus-antibodies.html), and its role in preventing re-infection is not yet clear. But, studies show that asymptomatic people are shedding the virus for potentially longer periods of time than symptomatic people.
+    * Antibodies don't last longer [than a couple months](https://www.nytimes.com/2020/06/18/health/coronavirus-antibodies.html), with the CDC later confirming that [antibodies may last 3 months](https://www.cdc.gov/coronavirus/2019-ncov/if-you-are-sick/quarantine.html). Its role in preventing re-infection is not yet clear. But, studies show that asymptomatic people are shedding the virus for potentially longer periods of time than symptomatic people.
 
 
 ## Known Unknowns


### PR DESCRIPTION
Switch out functions in `upload-data.py` to use the `civis_aqueduct_utils` package that we can install. Should be able to upload larger files.