### PR TITLE
Use rolling avg

### DIFF
--- a/notebooks/ca-counties.ipynb
+++ b/notebooks/ca-counties.ipynb
@@ -161,7 +161,7 @@
     "    \n",
     "    # Calculate its severity metric\n",
     "    df = df.assign(\n",
-    "        severity = (df.new_cases / df.tier3_case_cutoff).round(1)\n",
+    "        severity = (df.cases_avg7 / df.tier3_case_cutoff).round(1)\n",
     "    )\n",
     "    \n",
     "    # Make gdf\n",


### PR DESCRIPTION
Use 7-day rolling average instead of new cases yesterday to calculate severity. Otherwise, some counties have 0's.