### PR TITLE
Move CA open data away from Google sheet sources

### DIFF
--- a/data/create_data.py
+++ b/data/create_data.py
@@ -5,5 +5,12 @@ Less frequent updates.
 import jhu
 import jhu_county
 
+import ca_hospital
+import la_neighborhood
+
 jhu.load_global_covid_data()
 jhu_county.append_county_time_series()
+
+ca_hospital.update_ca_surge_hospital_data()
+
+la_neighborhood.update_neighborhood_data()

--- a/data/create_data_AM_hourly.py
+++ b/data/create_data_AM_hourly.py
@@ -4,12 +4,6 @@ Hourly updates because these depend on Google sheets.
 """
 import sync_covid_testing
 import sync_la_cases
-import ca_hospital
-import la_neighborhood
 
 sync_covid_testing.update_covid_testing_city_county_data()
 sync_la_cases.update_la_cases_data()
-
-ca_hospital.update_ca_surge_hospital_data()
-
-la_neighborhood.update_neighborhood_data()


### PR DESCRIPTION
Some scripts in `data/create_data_AM_hourly.py` haven't been running because the Google sheets aren't updated (debug that later). Move CA open data and RShiny sources into `data/create_data.py` so it still runs.