### PR TITLE
Add function to deal with outliers

### DIFF
--- a/notebooks/us_county_utils.py
+++ b/notebooks/us_county_utils.py
@@ -59,6 +59,7 @@ def clean_jhu(start_date):
                   on = "fips", how = "inner", validate = "m:1"
     )
     
+    df = utils.find_outliers(df, threshold=10)
     df = utils.calculate_rolling_average(df, start_date, today_date)
     df = utils.find_tier_cutoffs(df, "county_pop")
     df = utils.doubling_time(df, window=7)


### PR DESCRIPTION
In LA, on 5/27/21, it was recorded that there were 4,000+ new cases from the prior day. It's reflected in the raw data in JHU. Rather than suppressing individual outlier dates across counties, use a function that compares the new cases of a given day against new cases of prior day and the day after. If new cases recorded are more than 10x the previous day's or the day after's, then exclude that as outlier. Otherwise, outliers mess up our 7-day rolling average.